### PR TITLE
feat: Update form label from 'Local Government' to 'Local Govt Educ A…

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,7 @@ select.form-control option {
 			
 			 <div class="form-row">
                 <div class="form-group">
-                    <label for="silnat_localGov">Local Government *</label> <!-- This will be part of Section B -->
+                    <label for="silnat_localGov">Local Govt Educ Auth *</label> <!-- This will be part of Section B -->
                     <input type="text" id="silnat_localGov" name="silnat_b_local_gov_common" class="form-control" required="">
                 </div>
             </div>


### PR DESCRIPTION
…uth'

This commit updates the form label for the local government field in the 'Infrastructure & Leadership Tools 1.2: SPECIAL SCHOOLS (SILNAT 1.2)' section of the `index.html` file.

The label has been changed from 'Local Government' to 'Local Govt Educ Auth' to better reflect the correct terminology.