### PR TITLE
Fix: Standardize LGEA label and add required attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -2514,8 +2514,8 @@ select.form-control option {
         </div>
     </div>
 	<div class="form-group">
-        <label for="tcmats_lgea">LGEA:</label>
-        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control">
+        <label for="tcmats_lgea">Local Govt Educ Auth *</label>
+        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control" required="">
     </div>
     <div class="form-group">
         <label for="tcmats_schoolName">Name of School</label>
@@ -3045,8 +3045,8 @@ select.form-control option {
         </div>
     </div>
 	<div class="form-group">
-        <label for="tcmats_lgea">LGEA:</label>
-        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control">
+        <label for="voices_lgea">Local Govt Educ Auth *</label>
+        <input type="text" id="voices_lgea" name="voices_lgea" class="form-control" required="">
     </div>
     <div class="form-group">
         <label for="tcmats_schoolName">Name of School</label>


### PR DESCRIPTION
This change standardizes the 'LGEA' label to 'Local Govt Educ Auth *' in the TCMATS and VOICES survey forms to match the other forms on the page.

It also adds the 'required' attribute to the input fields to ensure the data is submitted.

Additionally, it fixes a bug where the 'for' and 'id' attributes were duplicated in the VOICES section.