### PR TITLE
feat: Update LGEA to Local Govt Educ Auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -1600,12 +1600,7 @@ select.form-control option {
             <div id="sectionBContent_1.4" style="display: none;">
                 <div class="form-group">
                     <label for="lgea_name_1.4">Local Govt Educ Auth</label>
-
                     <input type="text" id="lgea_name_1.4" name="lgea_name_1.4" class="form-control">
-                </div>
-                <div class="form-group">
-                    <label for="school_name_1.4">Name of School/Institution</label>
-                    <input type="text" id="school_name_1.4" name="school_name_1.4" class="form-control">
                 </div>
                 <div class="form-group">
                     <label for="lgea_address_1.4">Address</label>
@@ -2515,8 +2510,8 @@ select.form-control option {
         </div>
     </div>
 	<div class="form-group">
-        <label for="tcmats_lgea">Local Govt Educ Auth *</label>
-        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control" required="">
+        <label for="tcmats_lgea">LGEA:</label>
+        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control">
     </div>
     <div class="form-group">
         <label for="tcmats_schoolName">Name of School</label>
@@ -3046,8 +3041,8 @@ select.form-control option {
         </div>
     </div>
 	<div class="form-group">
-        <label for="voices_lgea">Local Govt Educ Auth *</label>
-        <input type="text" id="voices_lgea" name="voices_lgea" class="form-control" required="">
+        <label for="tcmats_lgea">LGEA:</label>
+        <input type="text" id="tcmats_lgea" name="tcmats_lgea" class="form-control">
     </div>
     <div class="form-group">
         <label for="tcmats_schoolName">Name of School</label>


### PR DESCRIPTION
Changed the name of LGEA to Local Govt Educ Auth in 'Infrastructure & Leadership Tools 1.4: LGEAS (SILNAT 1.4)' for Education Secretaries. This includes updating the survey card title and all occurrences of the acronym within the SILNAT 1.4 section for consistency.