### PR TITLE
feat: Reposition signout button on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,6 +542,15 @@ footer {
   box-shadow: 0 4px 24px rgba(30,64,175,0.10);
   padding: 32px 18px 24px 18px;
   margin-bottom: 32px;
+  position: relative;
+}
+
+.landing-signout-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: auto;
+    padding: 8px 16px;
 }
 
 
@@ -650,10 +659,10 @@ select.form-control option {
 
         <!-- Landing Page: Four Survey Cards -->
         <div id="landingPage" class="section">
+            <button class="btn btn-secondary landing-signout-btn" onclick="logout()">Sign Out</button>
             <div class="landing-header">
                 <img src="subeb.jpg" alt="LASUBEB Logo" class="landing-logo">
                 <h1 style="color:white;font-size:2.2rem; margin-left: 20px; flex-grow: 1; text-align: center;">Welcome to LASUBEB/PIMU Needs Assessment Portal</h1>
-				<button class="btn btn-secondary" style="width:auto;padding:8px 16px;margin-left:20px;" onclick="logout()">Sign Out</button>
             </div>
             <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:32px;max-width:1000px;margin:0 auto; margin-top: 32px;">
                 <div class="survey-card" onclick="showSurvey(&#39;silnat&#39;)">


### PR DESCRIPTION
Moved the signout button to be a direct child of the landing page container and used absolute positioning to place it in the top right corner. This ensures it remains in the top right on all screen sizes.