### PR TITLE
fix: Correct survey visibility logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3792,7 +3792,7 @@ select.form-control option {
     // Navigation logic for landing/surveys
     async function showSurvey(survey) {
         document.getElementById('landingPage').classList.add('hidden');
-        ['silnat','tcmats','lori','voices', 'silnat_new', 'silat_1.2', 'silat_1.3', 'silat_1.4'].forEach(s => {
+        ['silnat','tcmats','lori','voices', 'silat_1.2', 'silat_1.3', 'silat_1.4'].forEach(s => {
             const section = document.getElementById(s + 'Section');
             if (section) {
                 section.classList.add('hidden');


### PR DESCRIPTION
This change refactors the `showSurvey` Javascript function to correctly display the selected survey. The previous logic was preventing some surveys from being displayed.

This was caused by an invalid section name in the `forEach` loop that hides the sections.