### PR TITLE
Add a reports page to display survey results

### DIFF
--- a/index.html
+++ b/index.html
@@ -3508,6 +3508,7 @@ select.form-control option {
                     <div class="nav-item" onclick="showSection(&#39;audit&#39;)">📝 New Audit</div>
                     <div class="nav-item" onclick="showSection(&#39;records&#39;)">📋 Records</div>
                     <div class="nav-item" onclick="showSection(&#39;sync&#39;)">🔄 Sync Data</div>
+                    <div class="nav-item"><a href="/reports/" style="text-decoration: none; color: inherit;">📈 Reports</a></div>
                     
                     <h3>SECTION A: Demographic information of School and Bio Data of Teacher</h3>
                 </div>
@@ -3678,6 +3679,7 @@ select.form-control option {
                 <div class="nav-item" onclick="showSection(&#39;audit&#39;);toggleMobileSidebar();">📝 New Audit</div>
                 <div class="nav-item" onclick="showSection(&#39;records&#39;);toggleMobileSidebar();">📋 Records</div>
                 <div class="nav-item" onclick="showSection(&#39;sync&#39;);toggleMobileSidebar();">🔄 Sync Data</div>
+                <div class="nav-item"><a href="/reports/" style="text-decoration: none; color: inherit;">📈 Reports</a></div>
                 <button class="btn btn-secondary" style="margin-top:20px;" onclick="logout();toggleMobileSidebar();">Logout</button>
             </div>
         </div>

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Survey Reports</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        :root {
+            --lagos-red: #DC2626;
+            --lagos-blue: #1E40AF;
+            --lagos-yellow: #FACC15;
+            --lagos-green: #16A34A;
+            --lagos-white: #FFFFFF;
+            --lagos-navy: #1E3A8A;
+            --lagos-dark-gray: #64748B;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--lagos-blue);
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            min-height: 100vh;
+        }
+        .header {
+            background: var(--lagos-navy);
+            border-radius: 15px;
+            padding: 20px;
+            margin-bottom: 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            color: var(--lagos-white);
+            position: relative;
+            border-left: 8px solid var(--lagos-red);
+        }
+        .header .logo {
+            display: flex;
+            align-items: center;
+            font-size: 24px;
+            font-weight: bold;
+            color: var(--lagos-white);
+        }
+        .header .logo img {
+            height: 40px;
+            width: 40px;
+            margin-right: 12px;
+        }
+        .btn {
+            padding: 10px 20px;
+            background: var(--lagos-green);
+            color: var(--lagos-white);
+            border: 2px solid var(--lagos-yellow);
+            border-radius: 10px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-decoration: none;
+        }
+        .btn:hover {
+            background: var(--lagos-yellow);
+            border-color: var(--lagos-green);
+            color: var(--lagos-navy);
+        }
+        .content-area {
+            background: var(--lagos-white);
+            border-radius: 15px;
+            padding: 30px;
+            overflow-y: auto;
+            position: relative;
+            border-top: 4px solid var(--lagos-blue);
+        }
+        .data-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--lagos-white);
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        .data-table th,
+        .data-table td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #e5e7eb;
+            color: black !important;
+        }
+        .data-table th {
+            background: var(--lagos-blue);
+            color: var(--lagos-white);
+            font-weight: 600;
+        }
+        footer {
+            margin-top: 40px;
+            background: var(--lagos-navy);
+            color: var(--lagos-yellow);
+            text-align: center;
+            padding: 18px 0 10px 0;
+            border-top: 4px solid var(--lagos-green);
+            font-size: 1rem;
+            letter-spacing: 0.5px;
+        }
+        footer img {
+            height:32px;
+            width:32px;
+            vertical-align:middle;
+            margin-right:10px;
+            border-radius:6px;
+            border:2px solid var(--lagos-yellow);
+            background:var(--lagos-white);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="logo">
+                <img src="/subeb.jpg" alt="Lagos State Logo">
+                Survey Reports
+            </div>
+            <a href="/" class="btn">Back to Main App</a>
+        </div>
+
+        <div class="content-area">
+            <div id="reportsContainer">
+                <h2>Audit Reports</h2>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>School Name</th>
+                            <th>Local Government</th>
+                            <th>Date</th>
+                            <th>Principal</th>
+                            <th>Teachers</th>
+                            <th>Students</th>
+                            <th>Facility Condition</th>
+                            <th>Notes</th>
+                            <th>Photos</th>
+                        </tr>
+                    </thead>
+                    <tbody id="auditReportsTable">
+                        <!-- Data will be inserted here by reports.js -->
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Placeholder for other survey reports -->
+            <div id="silnatReportsContainer" style="margin-top: 40px;">
+                <h2>SILNAT Reports</h2>
+                <p>Data for this survey is not yet available.</p>
+            </div>
+            <div id="tcmatsReportsContainer" style="margin-top: 40px;">
+                <h2>TCMATS Reports</h2>
+                <p>Data for this survey is not yet available.</p>
+            </div>
+            <div id="loriReportsContainer" style="margin-top: 40px;">
+                <h2>LORI Reports</h2>
+                <p>Data for this survey is not yet available.</p>
+            </div>
+            <div id="voicesReportsContainer" style="margin-top: 40px;">
+                <h2>VOICES Reports</h2>
+                <p>Data for this survey is not yet available.</p>
+            </div>
+
+        </div>
+
+        <footer style="background:var(--lagos-navy);color:var(--lagos-yellow);text-align:center;padding:18px 0 10px 0;margin-top:40px;border-top:4px solid var(--lagos-green);font-size:1rem;letter-spacing:0.5px;">
+            <img src="/subeb.jpg" alt="Lagos State Logo">
+            Lagos State Universal Basic Education Board © 2025. All Rights Reserved. | Centre of Excellence
+        </footer>
+    </div>
+    <script src="reports.js"></script>
+</body>
+</html>

--- a/reports/reports.js
+++ b/reports/reports.js
@@ -1,0 +1,61 @@
+window.onload = function() {
+    fetchAuditReports();
+};
+
+function fetchAuditReports() {
+    const tableBody = document.getElementById('auditReportsTable');
+    if (!tableBody) {
+        console.error('Audit reports table body not found.');
+        return;
+    }
+
+    // Start with a loading message
+    tableBody.innerHTML = '<tr><td colspan="9">Loading reports...</td></tr>';
+
+    fetch('/api/audits')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(audits => {
+            renderAuditReports(audits);
+        })
+        .catch(error => {
+            console.error('Error fetching audit reports:', error);
+            tableBody.innerHTML = '<tr><td colspan="9" style="color:red;">Could not load reports. Please try again later.</td></tr>';
+        });
+}
+
+function renderAuditReports(audits) {
+    const tableBody = document.getElementById('auditReportsTable');
+    if (!audits || audits.length === 0) {
+        tableBody.innerHTML = '<tr><td colspan="9">No audit reports found.</td></tr>';
+        return;
+    }
+
+    // Clear loading message
+    tableBody.innerHTML = '';
+
+    audits.forEach(audit => {
+        const row = document.createElement('tr');
+
+        const photosHtml = audit.photos && audit.photos.length > 0
+            ? audit.photos.map(photo => `<a href="/api/photo/${encodeURIComponent(photo)}" target="_blank"><img src="/api/photo/${encodeURIComponent(photo)}" alt="photo" style="width: 50px; height: 50px; object-fit: cover; border-radius: 5px; margin: 2px;"></a>`).join('')
+            : 'No photos';
+
+        row.innerHTML = `
+            <td>${audit.schoolName || ''}</td>
+            <td>${audit.localGov || ''}</td>
+            <td>${new Date(audit.timestamp).toLocaleString() || ''}</td>
+            <td>${audit.principalName || ''}</td>
+            <td>${audit.totalTeachers || 0}</td>
+            <td>${audit.totalStudents || 0}</td>
+            <td>${audit.facilityCondition || ''}</td>
+            <td>${audit.additionalNotes || ''}</td>
+            <td>${photosHtml}</td>
+        `;
+        tableBody.appendChild(row);
+    });
+}


### PR DESCRIPTION
This change introduces a new subdirectory `reports/` containing a page to display the submitted survey data.

- Creates `reports/index.html` with a similar look and feel to the main application.
- Adds `reports/reports.js` to fetch and render audit data from the `/api/audits` endpoint.
- Modifies the main `index.html` to include a link to the new reports page in the sidebar.