### PR TITLE
feat: Add and correct submit buttons for SILNAT sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1608,9 +1608,9 @@ select.form-control option {
 						<tr><td>5</td><td><input type="text" class="form-control"></td><td><input type="number" class="form-control"></td><td><input type="number" class="form-control"></td></tr>
                     </tbody>
                 </table>	
+			</div>
         <button type="submit" class="btn">Submit SILNAT 1.3 Survey</button>
         <div id="silat_1.3_feedback" style="margin-top:15px;font-size:15px;"></div>
-        </div>
         </form>
     </div>
     <div id="silat_1.4Section" class="section hidden">
@@ -1628,6 +1628,7 @@ select.form-control option {
                 <br><br>
                 <u>Instruction:</u> The instrument has Four Sections. Section A requires Bio Data; Section B requires Institution Data; Section C contains items on Education Managers’ Needs Assessment while Section D is on School Infrastructure. Kindly fill in the statements that are applicable to your school.
             </div>
+            <button type="submit" class="btn" style="margin-bottom: 20px;">Submit SILNAT 1.4 Survey</button>
 
             <h4 id="sectionAHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionAContent_1.4&#39;, &#39;sectionAHeader_1.4&#39;)">Section A: Bio Data ▶️</h4>
             <div id="sectionAContent_1.4" style="display: none;">
@@ -1971,10 +1972,9 @@ select.form-control option {
                         <tr><td>3</td><td><input type="text" class="form-control"></td><td><input type="number" class="form-control"></td><td><input type="number" class="form-control"></td></tr>
                     </tbody>
                 </table>
-				<button type="submit" class="btn">Submit SILNAT 1.4 Survey</button>
-                <div id="silat_1.4_feedback" style="margin-top:15px;font-size:15px;"></div>
-				
             </div>
+            <button type="submit" class="btn">Submit SILNAT 1.4 Survey</button>
+            <div id="silat_1.4_feedback" style="margin-top:15px;font-size:15px;"></div>
             </form>
         </div>
 


### PR DESCRIPTION
This commit addresses inconsistencies in the submit button placements for the SILNAT survey sections.

- Adds a top submit button to the SILNAT 1.4 section, making it consistent with the 1.2 and 1.3 sections.
- Moves the bottom submit buttons for sections 1.3 and 1.4 to be outside of the collapsible 'Section D' container. This ensures they are always visible within the form, fixing a bug where they would be hidden until the section was expanded.