### PR TITLE
feat: Enhance reports page and add entry point

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,6 +691,11 @@ select.form-control option {
                     <h2>Learner Voices/Opinions<br>(VOICES)</h2>
                     <p>For Learners</p>
                 </div>
+
+                <div class="survey-card" onclick="window.location.href='/reports/'">
+                    <h2>View Submitted Reports</h2>
+                    <p>Access all survey data</p>
+                </div>
                
             </div>
         </div>

--- a/reports/index.html
+++ b/reports/index.html
@@ -156,19 +156,73 @@
             <!-- Placeholder for other survey reports -->
             <div id="silnatReportsContainer" style="margin-top: 40px;">
                 <h2>SILNAT Reports</h2>
-                <p>Data for this survey is not yet available.</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Institution Name</th>
+                            <th>LGEA</th>
+                            <th>Type</th>
+                            <th>Respondent</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="silnatReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
             </div>
             <div id="tcmatsReportsContainer" style="margin-top: 40px;">
                 <h2>TCMATS Reports</h2>
-                <p>Data for this survey is not yet available.</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Teacher Name</th>
+                            <th>School</th>
+                            <th>LGEA</th>
+                            <th>Subject</th>
+                            <th>Class</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="tcmatsReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
             </div>
             <div id="loriReportsContainer" style="margin-top: 40px;">
                 <h2>LORI Reports</h2>
-                <p>Data for this survey is not yet available.</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Assessor</th>
+                            <th>Teacher</th>
+                            <th>School</th>
+                            <th>Subject</th>
+                            <th>Overall Rating</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="loriReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
             </div>
             <div id="voicesReportsContainer" style="margin-top: 40px;">
                 <h2>VOICES Reports</h2>
-                <p>Data for this survey is not yet available.</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Learner Name</th>
+                            <th>School</th>
+                            <th>Class</th>
+                            <th>Opinion Snippet</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="voicesReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
             </div>
 
         </div>

--- a/reports/reports.js
+++ b/reports/reports.js
@@ -1,5 +1,10 @@
 window.onload = function() {
     fetchAuditReports();
+    // Fetch reports for all other surveys
+    fetchAndRender('silnat', 'silnatReportsTable', renderSilnatReportRow);
+    fetchAndRender('tcmats', 'tcmatsReportsTable', renderTcmatsReportRow);
+    fetchAndRender('lori', 'loriReportsTable', renderLoriReportRow);
+    fetchAndRender('voices', 'voicesReportsTable', renderVoicesReportRow);
 };
 
 function fetchAuditReports() {
@@ -8,15 +13,10 @@ function fetchAuditReports() {
         console.error('Audit reports table body not found.');
         return;
     }
-
-    // Start with a loading message
     tableBody.innerHTML = '<tr><td colspan="9">Loading reports...</td></tr>';
-
     fetch('/api/audits')
         .then(response => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             return response.json();
         })
         .then(audits => {
@@ -34,17 +34,12 @@ function renderAuditReports(audits) {
         tableBody.innerHTML = '<tr><td colspan="9">No audit reports found.</td></tr>';
         return;
     }
-
-    // Clear loading message
     tableBody.innerHTML = '';
-
     audits.forEach(audit => {
         const row = document.createElement('tr');
-
         const photosHtml = audit.photos && audit.photos.length > 0
             ? audit.photos.map(photo => `<a href="/api/photo/${encodeURIComponent(photo)}" target="_blank"><img src="/api/photo/${encodeURIComponent(photo)}" alt="photo" style="width: 50px; height: 50px; object-fit: cover; border-radius: 5px; margin: 2px;"></a>`).join('')
             : 'No photos';
-
         row.innerHTML = `
             <td>${audit.schoolName || ''}</td>
             <td>${audit.localGov || ''}</td>
@@ -58,4 +53,109 @@ function renderAuditReports(audits) {
         `;
         tableBody.appendChild(row);
     });
+}
+
+// Generic fetch and render function for other surveys
+function fetchAndRender(surveyName, tableBodyId, renderRowFunction) {
+    const tableBody = document.getElementById(tableBodyId);
+    if (!tableBody) {
+        console.error(`${surveyName} reports table body not found.`);
+        return;
+    }
+    const colSpan = tableBody.parentElement.querySelector('thead tr').childElementCount;
+    tableBody.innerHTML = `<tr><td colspan="${colSpan}">Loading reports...</td></tr>`;
+
+    fetch(`/api/${surveyName}`)
+        .then(response => {
+            if (response.status === 404) { // Handle case where API endpoint doesn't exist
+                return []; // Treat as empty data
+            }
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (!data || data.length === 0) {
+                tableBody.innerHTML = `<tr><td colspan="${colSpan}">No ${surveyName} reports found.</td></tr>`;
+                return;
+            }
+            tableBody.innerHTML = ''; // Clear loading message
+            data.forEach(item => {
+                const row = document.createElement('tr');
+                row.innerHTML = renderRowFunction(item);
+                tableBody.appendChild(row);
+            });
+        })
+        .catch(error => {
+            console.error(`Error fetching ${surveyName} reports:`, error);
+            tableBody.innerHTML = `<tr><td colspan="${colSpan}" style="color:red;">Could not load ${surveyName} reports.</td></tr>`;
+        });
+}
+
+// --- Row render functions for each survey type ---
+
+function renderSilnatReportRow(item) {
+    // Extract data, providing defaults for missing fields
+    const institutionName = item.section_b?.institution_name_common || 'N/A';
+    const lgea = item.section_b?.local_gov_common || 'N/A';
+    const type = item.institution_type?.replace(/_/g, ' ') || 'N/A';
+    const respondent = item.section_a?.head_teacher_name || item.section_a?.education_secretary_name || 'N/A';
+    const date = item.timestamp ? new Date(item.timestamp).toLocaleString() : 'N/A';
+    return `
+        <td>${institutionName}</td>
+        <td>${lgea}</td>
+        <td style="text-transform: capitalize;">${type}</td>
+        <td>${respondent}</td>
+        <td>${date}</td>
+    `;
+}
+
+function renderTcmatsReportRow(item) {
+    const teacherName = item.teacherName || 'N/A';
+    const school = item.school || 'N/A';
+    const lgea = item.lgea || 'N/A';
+    const subject = item.subject || 'N/A';
+    const className = item.class || 'N/A';
+    const date = item.timestamp ? new Date(item.timestamp).toLocaleString() : 'N/A';
+    return `
+        <td>${teacherName}</td>
+        <td>${school}</td>
+        <td>${lgea}</td>
+        <td>${subject}</td>
+        <td>${className}</td>
+        <td>${date}</td>
+    `;
+}
+
+function renderLoriReportRow(item) {
+    const assessor = item.assessorName || 'N/A';
+    const teacher = item.teacherName || 'N/A';
+    const school = item.school || 'N/A';
+    const subject = item.subject || 'N/A';
+    const rating = item.rating || 'N/A';
+    const date = item.timestamp ? new Date(item.timestamp).toLocaleString() : 'N/A';
+    return `
+        <td>${assessor}</td>
+        <td>${teacher}</td>
+        <td>${school}</td>
+        <td>${subject}</td>
+        <td>${rating}</td>
+        <td>${date}</td>
+    `;
+}
+
+function renderVoicesReportRow(item) {
+    const learnerName = item.learnerName || 'N/A';
+    const school = item.school || 'N/A';
+    const className = item.class || 'N/A';
+    const opinion = (item.opinion || '').substring(0, 50) + ( (item.opinion || '').length > 50 ? '...' : '');
+    const date = item.timestamp ? new Date(item.timestamp).toLocaleString() : 'N/A';
+    return `
+        <td>${learnerName}</td>
+        <td>${school}</td>
+        <td>${className}</td>
+        <td>${opinion}</td>
+        <td>${date}</td>
+    `;
 }


### PR DESCRIPTION
Adds a "View Reports" card to the main landing page to provide an easy entry point to the reports section.

The reports page has been enhanced to fetch and display reports for all survey types (SILNAT, TCMATS, LORI, VOICES) in addition to the existing audit reports. The page now includes tables for each survey type and the necessary JavaScript to populate them with data from their respective API endpoints.