### PR TITLE
feat: Enable local storage for all survey reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -5633,6 +5633,13 @@ async function submitSilat1_2(event) {
 
     console.log("Submitting SILAT 1.2 Data:", JSON.stringify(data, null, 2));
 
+    // Save to localStorage
+    data.id = Date.now();
+    data.timestamp = new Date().toISOString();
+    const silat1_2Data = JSON.parse(localStorage.getItem('silat_1.2Data')) || [];
+    silat1_2Data.push(data);
+    localStorage.setItem('silat_1.2Data', JSON.stringify(silat1_2Data));
+
     try {
         // Using a placeholder API endpoint
         const res = await fetch('/api/silat_1.2', {
@@ -5742,6 +5749,13 @@ async function submitSilat1_3(event) {
 
     console.log("Submitting SILAT 1.3 Data:", JSON.stringify(data, null, 2));
 
+    // Save to localStorage
+    data.id = Date.now();
+    data.timestamp = new Date().toISOString();
+    const silat1_3Data = JSON.parse(localStorage.getItem('silat_1.3Data')) || [];
+    silat1_3Data.push(data);
+    localStorage.setItem('silat_1.3Data', JSON.stringify(silat1_3Data));
+
     try {
         const res = await fetch('/api/silat_1.3', {
             method: 'POST',
@@ -5835,6 +5849,13 @@ async function submitSilat1_4(event) {
     // ... and so on for all of section C and D
 
     console.log("Submitting SILAT 1.4 Data:", JSON.stringify(data, null, 2));
+
+    // Save to localStorage
+    data.id = Date.now();
+    data.timestamp = new Date().toISOString();
+    const silat1_4Data = JSON.parse(localStorage.getItem('silat_1.4Data')) || [];
+    silat1_4Data.push(data);
+    localStorage.setItem('silat_1.4Data', JSON.stringify(silat1_4Data));
 
     try {
         const res = await fetch('/api/silat_1.4', {
@@ -6031,6 +6052,13 @@ async function submitSilnat(event) {
 
     console.log("Submitting SILNAT Data:", JSON.stringify(data, null, 2)); // For debugging
 
+    // Save to localStorage
+    data.id = Date.now();
+    data.timestamp = new Date().toISOString();
+    const silnatData = JSON.parse(localStorage.getItem('silnatData')) || [];
+    silnatData.push(data);
+    localStorage.setItem('silnatData', JSON.stringify(silnatData));
+
     try {
         const res = await fetch('/api/silnat', {
             method: 'POST',
@@ -6070,6 +6098,8 @@ async function submitTcmats(event) {
     feedback.textContent = 'Submitting...';
     feedback.style.color = 'var(--lagos-blue)';
     const data = {
+        id: Date.now(),
+        timestamp: new Date().toISOString(),
         teacherName: document.getElementById('tcmats_teacherName').value.trim(),
         school: document.getElementById('tcmats_school').value.trim(),
         subject: document.getElementById('tcmats_subject').value.trim(),
@@ -6077,6 +6107,12 @@ async function submitTcmats(event) {
         observation: document.getElementById('tcmats_observation').value.trim(),
         evidence: await processFiles(document.getElementById('tcmats_fileInput'), 3)
     };
+
+    // Save to localStorage
+    const tcmatsData = JSON.parse(localStorage.getItem('tcmatsData')) || [];
+    tcmatsData.push(data);
+    localStorage.setItem('tcmatsData', JSON.stringify(tcmatsData));
+
     try {
         const res = await fetch('/api/tcmats', {
             method: 'POST',
@@ -6116,6 +6152,8 @@ async function submitLori(event) {
     feedback.textContent = 'Submitting...';
     feedback.style.color = 'var(--lagos-blue)';
     const data = {
+        id: Date.now(),
+        timestamp: new Date().toISOString(),
         assessorName: document.getElementById('lori_assessorName').value.trim(),
         teacherName: document.getElementById('lori_teacherName').value.trim(),
         school: document.getElementById('lori_school').value.trim(),
@@ -6124,6 +6162,12 @@ async function submitLori(event) {
         comments: document.getElementById('lori_comments').value.trim(),
         evidence: await processFiles(document.getElementById('lori_fileInput'), 3)
     };
+
+    // Save to localStorage
+    const loriData = JSON.parse(localStorage.getItem('loriData')) || [];
+    loriData.push(data);
+    localStorage.setItem('loriData', JSON.stringify(loriData));
+
     try {
         const res = await fetch('/api/lori', {
             method: 'POST',
@@ -6163,6 +6207,8 @@ async function submitVoices(event) {
     feedback.textContent = 'Submitting...';
     feedback.style.color = 'var(--lagos-blue)';
     const data = {
+        id: Date.now(),
+        timestamp: new Date().toISOString(),
         learnerName: document.getElementById('voices_learnerName').value.trim(),
         age: document.getElementById('voices_age').value.trim(),
         school: document.getElementById('voices_school').value.trim(),
@@ -6170,6 +6216,12 @@ async function submitVoices(event) {
         opinion: document.getElementById('voices_opinion').value.trim(),
         evidence: await processFiles(document.getElementById('voices_fileInput'), 2)
     };
+
+    // Save to localStorage
+    const voicesData = JSON.parse(localStorage.getItem('voicesData')) || [];
+    voicesData.push(data);
+    localStorage.setItem('voicesData', JSON.stringify(voicesData));
+
     try {
         const res = await fetch('/api/voices', {
             method: 'POST',

--- a/reports/index.html
+++ b/reports/index.html
@@ -154,8 +154,55 @@
             </div>
 
             <!-- Placeholder for other survey reports -->
+            <div id="silat1_2ReportsContainer" style="margin-top: 40px;">
+                <h2>SILNAT 1.2 (Special Schools) Reports</h2>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Institution Name</th>
+                            <th>LGEA</th>
+                            <th>Respondent</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="silat1_2ReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
+            </div>
+            <div id="silat1_3ReportsContainer" style="margin-top: 40px;">
+                <h2>SILNAT 1.3 (Vocational Centers) Reports</h2>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Institution Name</th>
+                            <th>LGEA</th>
+                            <th>Respondent</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="silat1_3ReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
+            </div>
+            <div id="silat1_4ReportsContainer" style="margin-top: 40px;">
+                <h2>SILNAT 1.4 (LGEA) Reports</h2>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>LGEA</th>
+                            <th>Respondent</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="silat1_4ReportsTable">
+                        <!-- Data will be inserted here -->
+                    </tbody>
+                </table>
+            </div>
             <div id="silnatReportsContainer" style="margin-top: 40px;">
-                <h2>SILNAT Reports</h2>
+                <h2>SILNAT 1.1 (Regular Schools) Reports</h2>
                 <table class="data-table">
                     <thead>
                         <tr>


### PR DESCRIPTION
This change modifies the application to save all survey data to the browser's local storage and updates the reports page to display this local data.

Previously, only the main 'Audit' form saved data locally, while other survey forms (SILNAT, TCMATS, etc.) attempted to send data directly to a backend API. The reports page also relied on this API, causing it to be non-functional in an offline or backend-less environment.

The following changes were made:
- All survey form handling functions in `index.html` have been updated to save form data to a corresponding `localStorage` key (e.g., `silnatData`, `tcmatsData`).
- The reports page at `reports/index.html` has been updated with new tables to display all types of survey reports.
- The corresponding `reports/reports.js` script has been rewritten to fetch all data from `localStorage`, making the reports page fully functional without a backend.